### PR TITLE
Fix 503 error from the robot.

### DIFF
--- a/a3brWebService.c
+++ b/a3brWebService.c
@@ -414,7 +414,10 @@ void a3brSession(A3brWebServiceSession_typ *inst, A3brWebServiceCfg_typ *configu
 					//Reset the connection
 					//inst->connection[i].httpClient.enable = 0;
 					//inst->authState = A3BR_AUTH_ST_INIT;
-					inst->authState = A3BR_AUTH_ST_READY;
+					brsmemset(inst->auth.httpSession, 0, sizeof(inst->auth.httpSession));
+					brsmemset(inst->auth.ABBCX, 0, sizeof(inst->auth.ABBCX));
+					inst->connection[i].httpClient.abort = 1;
+					inst->authState = A3BR_AUTH_ST_INIT;
 					break;
 				default:
 					//Catch errors related to authentication only.
@@ -431,6 +434,7 @@ void a3brSession(A3brWebServiceSession_typ *inst, A3brWebServiceCfg_typ *configu
 		LLHttpRequest(&inst->connection[i].httpRequest);
 		
 		inst->connection[i].httpRequest.send = 0;
+		inst->connection[i].httpClient.abort = 0;
 
 		inst->connection[i].httpStatus = inst->connection[i].httpRequest.header.status;
 


### PR DESCRIPTION
Fix 503 error from the robot.

What?

if the robot reports a 503 we need to reset the authentication AND the tcp connection.

Why?

If we try to reuse the auth or try to make a new login with the old connection we will just keep getting this.